### PR TITLE
Triggers implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,14 @@ All notable changes to this project will be documented in this file.
 
 -   Added the `trigger:create:scheduler` and `trigger:delete:scheduler` commands to allow creating/deleting a Cloud Scheduler job to trigger the Cloud Run service. This supports both authenticated and unauthenticated invocations, and will create/setup service account as needed. `trigger:delete:scheduler` is invoked automatically with `crwt destroy`. This is the first of other potential trigger:[create/delete]:{method} triggers.
 -   Updated the `backend-gcloud-dataflow` template's README.md to utilize `trigger:create:scheduler`.
--   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.
 -   Documentation and formatting fixes.
 -   Re-ordered commands in help to be alphabetized in list (excluding init).
 -   Built in the initial deploy call from `crbt init` to `crbt deploy` which previously required manual execution.
+
+### Fixed
+
+-   Resolved an issue where sufficient permissions were not granted to Cloud Build service account with GKE.
+-   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.
 
 ## [0.1.1] - 2020-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 -   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.
 -   Documentation and formatting fixes.
 -   Re-ordered commands in help to be alphabetized in list (excluding init).
+-   Built in the initial deploy call from `crbt init` to `crbt deploy` which previously required manual execution.
 
 ## [0.1.1] - 2020-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,10 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 -   Added the `trigger:create:scheduler` and `trigger:delete:scheduler` commands to allow creating/deleting a Cloud Scheduler job to trigger the Cloud Run service. This supports both authenticated and unauthenticated invocations, and will create/setup service account as needed. `trigger:delete:scheduler` is invoked automatically with `crwt destroy`. This is the first of other potential trigger:[create/delete]:{method} triggers.
+-   Updated the `backend-gcloud-dataflow` template's README.md to utilize `trigger:create:scheduler`.
 -   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.
 -   Documentation and formatting fixes.
+-   Re-ordered commands in help to be alphabetized in list (excluding init).
 
 ## [0.1.1] - 2020-02-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+-   Added the `trigger:create:scheduler` and `trigger:delete:scheduler` commands to allow creating/deleting a Cloud Scheduler job to trigger the Cloud Run service. This supports both authenticated and unauthenticated invocations, and will create/setup service account as needed. `trigger:delete:scheduler` is invoked automatically with `crwt destroy`. This is the first of other potential trigger:[create/delete]:{method} triggers.
+-   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.
+-   Documentation and formatting fixes.
+
 ## [0.1.1] - 2020-02-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ It also provides functionality to:
 -   Provide automatic clean up of all deployed services and artifacts to retire the service.
 -   Interactively create an `app.json` file that can be used to non-interactive re-deploy the service.
 -   Redeploy the service and supporting services (including across other projects) by utilizing the `.crbt` configuration file.
+-   Create triggers using services like [Cloud Scheduler](https://cloud.google.com/scheduler) to invoke the service.
 
 ### How can I use it?
 
@@ -351,6 +352,35 @@ options:
 cloudbuild:
   newapplication-trigger: a389dcd2-a700-xxxx-99d2-20dce913f241
 mapping:    jan19-01.esquared.dev
+```
+
+#### Trigger Create (Cloud Scheduler) Example
+
+-   Create Cloud Scheduler HTTP GET trigger that runs every hour:
+
+```
+crbt trigger:create:scheduler --schedule "0 * * * *" --method GET
+```
+
+**Output Example:**
+
+```
+=== Cloud Scheduler Trigger Creation
+
+[ > ] Services API enabled: cloudscheduler
+[ > ] Services API enabled: appengine
+[ ! ] App Engine app not found. Attempting to create...
+[ ! ] App Engine app created in: us-east1
+[ ? ] What service account would you like to use (name only, not email)? feb17-01-invoker
+[ ! ] Service account not found. Attempting to create...
+[ > ] Service Account created: feb17-01-invoker@es-lab5.iam.gserviceaccount.com
+[ > ] Cloud Run IAM Policy Binding added (feb17-01-invoker@es-lab5.iam.gserviceaccount.com): roles/run.invoker
+[ > ] Using schedule: 0 * * * *
+[ > ] Using method: GET
+[ > ] Cloud Scheduler trigger created.
+[ > ] Configuration saved to file (.crbt): trigger -> serviceAccount -> feb17-01-invoker@es-lab5.iam.gserviceaccount.com
+[ > ] Configuration saved to file (.crbt): trigger -> name -> scheduler-feb17-01
+[ > ] Configuration saved to file (.crbt): trigger -> type -> scheduler
 ```
 
 ## Frequently Asked Questions (FAQ)

--- a/README.md
+++ b/README.md
@@ -121,15 +121,17 @@ Below is a brief list of the available commands and their function:
 
 ### Commands
 
-| Command               | Description                                                                                                                                                                                                                                         |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **init**              | Setup a new application in the current directory. This command will create a `crbt.conf` configuration file in your current directory. It will also look for an `app.json` for customization parameters.                                            |
-| **customize**         | Re-parse the `app.json` file, and re-prompt for environment variables.                                                                                                                                                                              |
-| **deploy**            | Deploys the Cloud Run service within the current directory. Relies on a `cloudbuild.yaml` file and the local project directory. This is the method to deploy the service if automatic Cloud Build triggers were not selected during initialization. |
-| **destroy** [feature] | Destroys deployed services, but does not delete local code. [feature] can be `all` (Default) or `cloudrun`.                                                                                                                                         |
-| **status**            | Output current configuration status.                                                                                                                                                                                                                |
-| **list**              | List available built-in templates for Cloud Run services.                                                                                                                                                                                           |
-| **help**              | Display help information about the CLI or specific commands.                                                                                                                                                                                        |
+| Command                      | Description                                                                                                                                                                                                                                         |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **init**                     | Setup a new application in the current directory. This command will create a `crbt.conf` configuration file in your current directory. It will also look for an `app.json` for customization parameters.                                            |
+| **customize**                | Re-parse the `app.json` file, and re-prompt for environment variables.                                                                                                                                                                              |
+| **deploy**                   | Deploys the Cloud Run service within the current directory. Relies on a `cloudbuild.yaml` file and the local project directory. This is the method to deploy the service if automatic Cloud Build triggers were not selected during initialization. |
+| **destroy** [feature]        | Destroys deployed services, but does not delete local code. [feature] can be `all` (Default) or `cloudrun`.                                                                                                                                         |
+| **list**                     | List available built-in templates for Cloud Run services.                                                                                                                                                                                           |
+| **status**                   | Output current configuration status.                                                                                                                                                                                                                |
+| **trigger:create:scheduler** | Create a new Cloud Scheduler trigger for the Cloud Run service.                                                                                                                                                                                     |
+| **trigger:delete:scheduler** | Delete a Cloud Scheduler trigger for the Cloud Run service.                                                                                                                                                                                         |
+| **help**                     | Display help information about the CLI or specific commands.                                                                                                                                                                                        |
 
 ### Command Options
 
@@ -181,13 +183,39 @@ Destroys deployed services. [feature] can be:
 | **-r, --rep**      | Override and specify Cloud Source Repositories repo to delete.                              |
 | **-v, --verbose**  | Verbose mode                                                                                |
 
+#### list
+
+This command does not have any options.
+
 #### status
 
 This command does not have any options.
 
-#### list
+#### trigger:create:scheduler
 
-This command does not have any options.
+Create a new [Cloud Scheduler](https://cloud.google.com/scheduler) [trigger](https://cloud.google.com/run/docs/triggering/using-scheduler) for the Cloud Run service that calls the service based on [cron](https://en.wikipedia.org/wiki/Cron#Overview) format.
+
+| Option             | Description                                                                                     |
+| ------------------ | ----------------------------------------------------------------------------------------------- |
+| **-s, --schedule** | Schedule on which the job will be executed. (unix-cron format)                                  |
+| **-m, --method**   | HTTP method to use for the request [GET, PUT, POST]                                             |
+| **-b, --body**     | Data payload to be included as the body of the HTTP request. (only valid for PUT, POST methods) |
+| **-a, --account**  | Service account used to authenticate to the Cloud Run service (name only, not email)            |
+| **-d, --dryrun**   | Only show commands, but do not execute them in GCP                                              |
+| **-v, --verbose**  | Verbose mode                                                                                    |
+
+Additional Cloud Scheduler trigger documentation:
+
+-   Cloud SDK > [gcloud scheduler jobs create http](https://cloud.google.com/sdk/gcloud/reference/scheduler/jobs/create/http)
+-   Cloud Run > [Running services on a schedule](https://cloud.google.com/run/docs/triggering/using-scheduler)
+
+#### trigger:delete:scheduler
+
+Remove a [Cloud Scheduler](https://cloud.google.com/scheduler) [trigger](https://cloud.google.com/run/docs/triggering/using-scheduler) for the Cloud Run service.
+
+| Option            | Description  |
+| ----------------- | ------------ |
+| **-v, --verbose** | Verbose mode |
 
 ### Customizing deployment parameters
 

--- a/destroy/index.js
+++ b/destroy/index.js
@@ -24,6 +24,7 @@ const cloudrun = require('./cloudrun/index');
 const csr = require('./csr/index');
 const cloudbuild = require('./cloudbuild/index');
 const domain = require('./domain/index');
+const schedulerDelete = require('../trigger/delete/scheduler/index');
 
 const { getConfig, removeConfigSection } = require('../lib/parseConfig');
 const { clc, header, failure, warn, highlight, questionPrefix, varFmt } = require('../lib/colorScheme');
@@ -108,6 +109,10 @@ async function main(options, answers, mode) {
         if (mode == 'cloudrun') {
             cloudrun(options);
         } else {
+            // Remove trigger first
+            let triggerType = getConfig('trigger', 'type');
+            if (triggerType === 'scheduler') await schedulerDelete(options);
+
             await csr(options);
             await cloudbuild(options);
             await cloudrun(options);

--- a/index.js
+++ b/index.js
@@ -53,31 +53,6 @@ program
         initialize(options);
     });
 
-// This command runs Cloud Build directly; this is primarily used when a Cloud Build trigger wasn't created to automatically run it.
-program
-    .command('deploy')
-    .description('Build and deploy services')
-    .option('-v, --verbose', 'Verbose mode')
-    .action((options) => {
-        deploy(options);
-    });
-
-// Parse the config file and return it in a human readable YAML-style format to show the status.
-program
-    .command('status')
-    .description('Print status')
-    .action(() => {
-        status();
-    });
-
-// List available templates (used if using a template as a base for source code).
-program
-    .command('list')
-    .description('List available templates')
-    .action(() => {
-        list();
-    });
-
 // Handle customization of the service, specifically relating to environment variables currently. This can be called directly via `crbt customize` or as part of the init process.
 program
     .command('customize')
@@ -87,6 +62,15 @@ program
     .option('-v, --verbose', 'Verbose mode')
     .action((options) => {
         customize(options, true);
+    });
+
+// This command runs Cloud Build directly; this is primarily used when a Cloud Build trigger wasn't created to automatically run it.
+program
+    .command('deploy')
+    .description('Build and deploy services')
+    .option('-v, --verbose', 'Verbose mode')
+    .action((options) => {
+        deploy(options);
     });
 
 // Handle destruction of services previously created. Only runs if the current directory has a .crbt file and utilizes that to determine what to remove.
@@ -99,6 +83,22 @@ program
     .option('-v, --verbose', 'Verbose mode')
     .action((options) => {
         destroy(options);
+    });
+
+// List available templates (used if using a template as a base for source code).
+program
+    .command('list')
+    .description('List available templates')
+    .action(() => {
+        list();
+    });
+
+// Parse the config file and return it in a human readable YAML-style format to show the status.
+program
+    .command('status')
+    .description('Print status')
+    .action(() => {
+        status();
     });
 
 // This command creates a Cloud Scheduler job to trigger the Cloud Run service.

--- a/index.js
+++ b/index.js
@@ -25,6 +25,8 @@ const deploy = require('./deploy/index');
 const destroy = require('./destroy/index');
 const status = require('./status/index');
 const customize = require('./customize/index');
+const schedulerCreate = require('./trigger/create/scheduler/index');
+const schedulerDelete = require('./trigger/delete/scheduler/index');
 const { list } = require('./list/index');
 
 // Options
@@ -91,12 +93,35 @@ program
 program
     .command('destroy')
     .description('Destroy all enabled services from the current directory')
-    .option('-y, --yes', 'Confirm destroying entire project with no prompts.')
+    .option('-y, --yes', 'Confirm destroying entire project with no prompts')
     .option('-p, --preserve', "Don't delete .crbt config")
-    .option('-r, --repo [repo]', 'Override and specify CSR repo to delete.')
+    .option('-r, --repo [repo]', 'Override and specify CSR repo to delete')
     .option('-v, --verbose', 'Verbose mode')
     .action((options) => {
         destroy(options);
+    });
+
+// This command creates a Cloud Scheduler job to trigger the Cloud Run service.
+program
+    .command('trigger:create:scheduler')
+    .description('Create a new Cloud Scheduler trigger for the Cloud Run service')
+    .option('-s, --schedule [schedule]', 'Schedule on which the job will be executed. (unix-cron format)')
+    .option('-m, --method [method]', 'HTTP method to use for the request [GET, PUT, POST]')
+    .option('-b, --body [message]', 'Data payload to be included as the body of the HTTP request. (only valid for PUT, POST methods)')
+    .option('-a, --account [service account]', 'Service account used to authenticate to the Cloud Run service (name only, not email)')
+    .option('-d, --dryrun', 'Only show commands, but do not execute them in GCP')
+    .option('-v, --verbose', 'Verbose mode')
+    .action((options) => {
+        schedulerCreate(options);
+    });
+
+// This command deletes a Cloud Scheduler job that was used to trigger the Cloud Run service.
+program
+    .command('trigger:delete:scheduler')
+    .description('Delete a Cloud Scheduler trigger for the Cloud Run service')
+    .option('-v, --verbose', 'Verbose mode')
+    .action((options) => {
+        schedulerDelete(options);
     });
 
 program.parse(process.argv);

--- a/init/cloudbuild/index.js
+++ b/init/cloudbuild/index.js
@@ -86,7 +86,7 @@ const cloudbuild = async (options) => {
                     return resolve();
                 } else if (answers.cloudbuild == 'No') {
                     options.build = 'none';
-                    console.log(success('Skipping trigger setup...'));
+                    console.log(success('Skipping trigger setup...\n'));
                     return resolve();
                 }
             });

--- a/init/cloudbuild/index.js
+++ b/init/cloudbuild/index.js
@@ -49,7 +49,7 @@ const cloudbuild = async (options) => {
 
         if (options.build) {
             if (options.build == 'commit') {
-                setupCloudbuildIAM(options.dryrun, options.verbose);
+                setupCloudbuildIAM(options.platform, options.dryrun, options.verbose);
                 await enableTriggers(options.name, options.dryrun, options.verbose).catch((e) => {
                     console.log(failure('Fatal error. Recommend cleaning up with `crbt destroy`. Exiting...'));
                     process.exit(1);
@@ -79,7 +79,7 @@ const cloudbuild = async (options) => {
                 // It doesn't make sense to have a trigger for one service but not the others, so enable for all.
                 if (answers.cloudbuild == 'Yes') {
                     options.build = 'commit';
-                    setupCloudbuildIAM(options.dryrun, options.verbose);
+                    setupCloudbuildIAM(options.platform, options.dryrun, options.verbose);
                     await enableTriggers(options.name, options.dryrun, options.verbose).catch((e) => {
                         console.log(failure('Fatal error. Recommend cleaning up with `crbt destroy`. Exiting...'));
                     });
@@ -253,15 +253,17 @@ async function enableTriggers(name, dryrun, verbose) {
  * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  * @param {boolean} verbose - Verbosity level.
  */
-function setupCloudbuildIAM(dryrun, verbose) {
+function setupCloudbuildIAM(platform, dryrun, verbose) {
     let projectId = getConfig('project', 'id');
 
     let runAdminCommand = ['projects', 'add-iam-policy-binding', projectId, '--member=serviceAccount:' + projectId + '@cloudbuild.gserviceaccount.com', '--role=roles/run.admin'];
     let serviceAccountUserIAMCommand = ['projects', 'add-iam-policy-binding', projectId, '--member=serviceAccount:' + projectId + '@cloudbuild.gserviceaccount.com', '--role=roles/iam.serviceAccountUser'];
+    let gkeDevelCommand = ['projects', 'add-iam-policy-binding', projectId, '--member=serviceAccount:' + projectId + '@cloudbuild.gserviceaccount.com', '--role=roles/container.developer'];
 
     if (dryrun) {
         displayCommand('gcloud', runAdminCommand);
         displayCommand('gcloud', serviceAccountUserIAMCommand);
+        if (platform === 'gke') displayCommand('gcloud', gkeDevelCommand);
         return;
     }
 
@@ -285,6 +287,19 @@ function setupCloudbuildIAM(dryrun, verbose) {
         console.log(success('Cloud Build IAM Policy added (' + varFmt(projectId + '@cloudbuild.gserviceaccount.com') + '): ' + varFmt('roles/iam.serviceAccountUser')));
     } else {
         console.log(failure('Cloud Build IAM Policy Creation Failed: ' + varFmt('roles/iam.serviceAccountUser')));
+    }
+
+    if (platform === 'gke') {
+        let gkeDevelIAM = spawn('gcloud', gkeDevelCommand);
+        if (verbose) {
+            if (gkeDevelIAM.stdout.toString('utf8') !== '') console.log(gkeDevelIAM.stdout.toString('utf8'));
+            if (gkeDevelIAM.stderr.toString('utf8') !== '') console.log(gkeDevelIAM.stderr.toString('utf8'));
+        }
+        if (gkeDevelIAM.status === 0) {
+            console.log(success('Cloud Build IAM Policy added (' + varFmt(projectId + '@cloudbuild.gserviceaccount.com') + '): ' + varFmt('roles/run.admin')));
+        } else {
+            console.log(failure('Cloud Build IAM Policy Creation Failed:' + varFmt('roles/run.admin')));
+        }
     }
 }
 

--- a/init/csr/index.js
+++ b/init/csr/index.js
@@ -63,15 +63,15 @@ const csr = async (options) => {
             });
         }
 
-        await saveConfig('cloudrun', options.name);
+        await saveConfig('cloudrun', options.name, 'placeholder');
         return resolve();
     });
 };
 
 /**
  * Run git initialization within the current directory.
- * @param {*} verbose - Verbosity level.
- * @param {*} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
+ * @param {boolean} verbose - Verbosity level.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  */
 const initializeGit = function(verbose, dryrun) {
     if (dryrun) {
@@ -133,8 +133,8 @@ const createRepo = function(repoName, dryrun, verbose) {
  * Clone from sourceRepo repository and then swap the remote origin to the destinationRepo.
  * @param {string} sourceRepo - Source repository to clone the code from.
  * @param {string} destinationRepo - New repository name to set the origin in git to.
- * @param {*} verbose - Verbosity level.
- * @param {*} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
+ * @param {boolean} verbose - Verbosity level.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  */
 const cloneExternalRepo = function(sourceRepo, destinationRepo, verbose, dryrun) {
     return new Promise(async (resolve, reject) => {
@@ -172,8 +172,8 @@ const cloneExternalRepo = function(sourceRepo, destinationRepo, verbose, dryrun)
 /**
  * Set the remote origin in git to the CSR repo.
  * @param {string} destinationRepo - New repository name to set the origin in git to.
- * @param {*} verbose - Verbosity level.
- * @param {*} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
+ * @param {boolean} verbose - Verbosity level.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  */
 const setRemoteOriginToCSR = function(destinationRepo, verbose, dryrun) {
     return new Promise(async (resolve, reject) => {

--- a/init/domain/index.js
+++ b/init/domain/index.js
@@ -165,8 +165,8 @@ const checkDNSSetup = function(domain) {
  * @param {string} domain - Custom domain address.
  * @param {string} service - Service to bind the address to.
  * @param {string} region - Region the service exists.
- * @param {string} verbose - Verbosity.
- * @param {string} dryrun - Dry-run true/false.
+ * @param {boolean} verbose - Verbosity.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  * @returns {boolean} - True if mapping is successful.
  */
 const createDomainMapping = function(domain, service, region, verbose, dryrun) {

--- a/init/index.js
+++ b/init/index.js
@@ -25,6 +25,7 @@ const git = require('./git/index');
 const cloudbuild = require('./cloudbuild/index');
 const domain = require('./domain/index');
 const findServices = require('../lib/findServices');
+const deploySubmit = require('../deploy/index');
 const customize = require('../customize/index');
 const { populateTemplateList } = require('../list/index');
 const enableAPI = require('../lib/enableAPI');
@@ -91,9 +92,9 @@ const initialize = async function(options) {
     }
 
     // Enable required GCP Service APIs.
-    enableAPI('sourcerepo', options.dryrun, options.verbose);
-    enableAPI('cloudbuild', options.dryrun, options.verbose);
-    enableAPI('run', options.dryrun, options.verbose);
+    enableAPI('sourcerepo', options.verbose, options.dryrun);
+    enableAPI('cloudbuild', options.verbose, options.dryrun);
+    enableAPI('run', options.verbose, options.dryrun);
 
     await saveConfig('name', options.name); // Could put this below, but it's visually more appealing to have this first in the config.
 
@@ -135,9 +136,10 @@ const initialize = async function(options) {
         if (!options.dryrun) console.log(highlight('\ncrbt initialization complete!'));
         else console.log(highlight('\ncrbt dry run complete!'));
     } else {
-        console.log(highlight('\ncrbt initialization complete!\n'));
-        console.log(warn('Since automated builds were not enabled, to perform deployment execute: ' + header('crbt deploy')));
-        if (options.map) console.log(warn('Domain mapping is not supported without automatic builds, since the service must first be deployed.'));
+        deploySubmit(options);
+        //console.log(highlight('\ncrbt initialization complete!\n'));
+        //console.log(warn('Since automated builds were not enabled, to perform deployment execute: ' + header('crbt deploy')));
+        //if (options.map) console.log(warn('Domain mapping is not supported without automatic builds, since the service must first be deployed.'));
     }
 };
 

--- a/lib/displayCommand.js
+++ b/lib/displayCommand.js
@@ -26,6 +26,7 @@ const { success, clc } = require('./colorScheme');
 const displayCommand = (command, args) => {
     let cmd = command;
     args.forEach((arg) => {
+        if (arg.includes('*')) arg = '"' + arg + '"'; // This catches asterisks when doing a Cloud Scheduler cron command, for example. There is no instance where we pass a wild-card to the shell.
         cmd += ' ' + arg;
     });
     console.log(success('Run the following command: '));

--- a/lib/enableAPI.js
+++ b/lib/enableAPI.js
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const spawn = require('child_process').spawnSync;
+const displayCommand = require('./displayCommand');
+
+const { success, failure, varFmt } = require('./colorScheme');
+
+/**
+ * Check if a Cloud API is enabled and if not then enable it, which will allow usage of the service.
+ * @param {string} service - GCP Service to enable.
+ */
+const enableAPI = (service, dryrun, verbose) => {
+    let command = ['services', 'enable', service + '.googleapis.com'];
+    if (dryrun) {
+        displayCommand('gcloud', command);
+        return;
+    }
+    let serviceEnable = spawn('gcloud', command);
+    if (verbose) {
+        if (serviceEnable.stdout.toString('utf8') !== '') console.log(serviceEnable.stdout.toString('utf8'));
+        if (serviceEnable.stderr.toString('utf8') !== '') console.log(serviceEnable.stderr.toString('utf8'));
+    }
+    if (serviceEnable.status === 0) {
+        console.log(success('Services API enabled: ' + varFmt(service)));
+    } else {
+        console.log(failure('Services API failed to enable: ' + varFmt(service)));
+        process.exit(1);
+    }
+};
+
+module.exports = enableAPI;

--- a/lib/enableAPI.js
+++ b/lib/enableAPI.js
@@ -24,8 +24,10 @@ const { success, failure, varFmt } = require('./colorScheme');
 /**
  * Check if a Cloud API is enabled and if not then enable it, which will allow usage of the service.
  * @param {string} service - GCP Service to enable.
+ * @param {boolean} verbose - Verbosity.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
  */
-const enableAPI = (service, dryrun, verbose) => {
+const enableAPI = (service, verbose, dryrun) => {
     let command = ['services', 'enable', service + '.googleapis.com'];
     if (dryrun) {
         displayCommand('gcloud', command);

--- a/lib/parseConfig.js
+++ b/lib/parseConfig.js
@@ -63,12 +63,7 @@ function saveConfig(section, feature, value) {
         if (jsonConfig[section] == undefined) {
             jsonConfig[section] = {};
         } // Create second-level if doesn't exist.
-        if (section == 'cloudrun') {
-            // Cloud Run section has a bit different tree than most.
-            jsonConfig[section][feature] = {};
-            jsonConfig[section][feature]['url'] = value;
-            jsonConfig = JSON.stringify(jsonConfig, null, 2);
-        } else if (value == undefined) {
+        if (value == undefined) {
             jsonConfig[section] = feature;
             jsonConfig = JSON.stringify(jsonConfig, null, 2);
         } else {
@@ -113,7 +108,7 @@ function getConfig(section, feature) {
  * Remove an entire section of config; for example, once a service like Cloud Build is no longer in use, remove the entire `cloudbuild` section.
  * @param {string} section - Sections correspond to different service areas (e.g. cloudbuild).
  */
-function removeConfigSection(section) {
+function removeConfigSection(section, feature) {
     return new Promise((resolve, reject) => {
         //try {
         let jsonConfig = JSON.parse(fs.readFileSync(configFile));
@@ -121,6 +116,15 @@ function removeConfigSection(section) {
         if (Object.keys(jsonConfig).length > 1 && section == 'project') {
             console.log(warn('Not deleting project from config as other sections remain. Recommend reviewing ' + varFmt('.crbt') + ' to see what may have persisted.')); // We want to keep the project key if the file is not otherwise empty.
             return resolve();
+        } else if (feature !== undefined) {
+            delete jsonConfig[section][feature];
+            jsonConfig = JSON.stringify(jsonConfig, null, 2);
+
+            fs.outputFile(configFile, jsonConfig, function(err) {
+                if (err) throw err;
+                console.log(success('Section > feature removed from config: ' + varFmt(section) + ' > ' + varFmt(feature) + '\n'));
+                return resolve();
+            });
         } else {
             delete jsonConfig[section];
             if (Object.keys(jsonConfig).length === 0) {

--- a/lib/parseConfig.js
+++ b/lib/parseConfig.js
@@ -98,9 +98,17 @@ function getConfig(section, feature) {
         // Return everything if nothing specific is asked for.
         return jsonConfig;
     } else if (feature == null) {
-        return jsonConfig[section];
+        try {
+            return jsonConfig[section];
+        } catch (e) {
+            return undefined;
+        }
     } else {
-        return jsonConfig[section][feature];
+        try {
+            return jsonConfig[section][feature];
+        } catch (e) {
+            return undefined;
+        }
     }
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "crbt",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/trigger/create/scheduler/index.js
+++ b/trigger/create/scheduler/index.js
@@ -36,7 +36,11 @@ const schedulerCreate = async function(options) {
     let serviceUrl = getConfig('cloudrun', serviceName);
     let platform = getConfig('platform');
     let project = getConfig('project', 'name');
-    let allowUnauthenticated = getConfig('options', 'allow-unauthenticated');
+
+    let allowUnauthenticated;
+    // allowUnauthenticated is not applicable to gke with crbt.
+    if (platform === 'gke') allowUnauthenticated = true;
+    else allowUnauthenticated = getConfig('options', 'allow-unauthenticated');
 
     // We rely on this being a crbt project for configuration parameters, so exit if anything is missing. No successful, valid deployment should be missing these.
     if (serviceName === undefined || allowUnauthenticated === undefined || serviceName === undefined || platform === undefined || project === undefined || serviceUrl === undefined) {

--- a/trigger/create/scheduler/index.js
+++ b/trigger/create/scheduler/index.js
@@ -1,0 +1,333 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const spawn = require('child_process').spawnSync;
+const inquirer = require('inquirer');
+const enableAPI = require('../../../lib/enableAPI');
+
+const displayCommand = require('../../../lib/displayCommand');
+const { success, warn, failure, header, questionPrefix, varFmt, clc } = require('../../../lib/colorScheme');
+const { saveConfig, getConfig } = require('../../../lib/parseConfig');
+
+/**
+ * Create a Cloud Scheduler trigger to call the Cloud Run service on an interval.
+ * @param {object} options - Initialized from commander.js.
+ */
+const schedulerCreate = async function(options) {
+    console.log(header('\n=== Cloud Scheduler Trigger Creation\n'));
+
+    let serviceName = getConfig('name');
+    let serviceUrl = getConfig('cloudrun', serviceName);
+    let platform = getConfig('platform');
+    let project = getConfig('project', 'name');
+    let allowUnauthenticated = getConfig('options', 'allow-unauthenticated');
+
+    // We rely on this being a crbt project for configuration parameters.
+    if (serviceName === undefined || allowUnauthenticated === undefined || serviceName === undefined || platform === undefined || project === undefined || serviceUrl === undefined) {
+        console.log(failure('Unable to detect all necessary values within configuration. Make sure service was initialized properly with crbt. Exiting...'));
+        process.exit(1);
+    }
+    let region;
+    let cluster;
+    let clusterzone;
+    if (platform === 'managed') {
+        region = getConfig('region');
+        if (region === undefined) {
+            console.log(failure('Unable to detect all necessary values within configuration. Make sure service was initialized properly with crbt. Exiting...'));
+            process.exit(1);
+        }
+    } else if (platform === 'gke') {
+        cluster = getConfig('cluster');
+        clusterzone = getConfig('clusterzone');
+        if (cluster === undefined || clusterzone === undefined) {
+            console.log(failure('Unable to detect all necessary values within configuration. Make sure service was initialized properly with crbt. Exiting...'));
+            process.exit(1);
+        }
+    }
+
+    // From a crbt perspective, we only want to support 1 trigger (excluding regular HTTP trigger).
+    if (getConfig('trigger') !== undefined) {
+        console.log(warn('crbt only supports creating one (1) trigger. Additional triggers can be created manually without crbt.'));
+        console.log(failure('Existing trigger has already been created. Exiting...'));
+        process.exit(1);
+    }
+
+    // Enable the Cloud Scheduler API: gcloud services enable cloudscheduler.googleapis.com
+    enableAPI('cloudscheduler', options.dryrun, options.verbose);
+
+    // If unauthenticated invocations are not allowed, we have to use a service account to invoke the service.
+    if (allowUnauthenticated === false) {
+        if (!options.account) options.account = await determineServiceAccount();
+        else console.log(success('Using service account: ') + varFmt(options.account));
+
+        // Convert simple name to full email-based name.
+        options.account = options.account + '@' + project + '.iam.gserviceaccount.com';
+
+        await checkServiceAccount(options.account, options.verbose, options.dryrun);
+
+        let iamCommand;
+        if (platform === 'managed') {
+            iamCommand = ['run', 'services', 'add-iam-policy-binding', serviceName, '--member=serviceAccount:' + options.account, '--role=roles/run.invoker', '--platform=managed', '--region=' + region];
+        } else if (platform === 'gke') {
+            iamCommand = ['run', 'services', 'add-iam-policy-binding', serviceName, '--member=serviceAccount:' + options.account, '--role=roles/run.invoker', '--platform=gke', '--cluster=' + cluster, '--cluster-location=' + clusterzone];
+        }
+        if (options.dryrun) {
+            displayCommand('gcloud', iamCommand);
+        } else {
+            const iamCreate = spawn('gcloud', iamCommand);
+            if (options.verbose) {
+                if (iamCreate.stdout.toString('utf8') !== '') console.log(iamCreate.stdout.toString('utf8'));
+                if (iamCreate.stderr.toString('utf8') !== '') console.log(iamCreate.stderr.toString('utf8'));
+            }
+            if (iamCreate.status === 0) {
+                console.log(success('Cloud Run IAM Policy Binding added (' + varFmt(options.account) + '): ' + varFmt('roles/run.invoker')));
+                await saveConfig('trigger', 'serviceAccount', options.account);
+            } else {
+                console.log(failure('Cloud Run IAM Policy Binding failed.'));
+                process.exit(1);
+            }
+        }
+    } else {
+        console.log(warn('Cloud Run service is configured to allow unauthenticated invocations, therefore skipping service account authentication...'));
+    }
+
+    let jobName = 'scheduler-' + serviceName;
+    if (!options.schedule) options.schedule = await determineSchedule();
+    else console.log(success('Using schedule: ') + varFmt(options.schedule));
+
+    if (!options.method) options.method = await determineHttpMethod();
+    else console.log(success('Using method: ') + varFmt(options.method));
+
+    // If HTTP method is PUT or POST, determine what message body to pass.
+    if (options.method === 'PUT' || options.method === 'POST') {
+        if (!options.body) options.body = await determineMessageBody();
+        else console.log(success('Using message body: ') + varFmt(options.body));
+    }
+
+    let schedulerCommand = ['scheduler', 'jobs', 'create', 'http', jobName, '--schedule', options.schedule, '--uri=' + serviceUrl, '--http-method=' + options.method];
+    if (options.body) command.push('--message-body=' + options.body);
+    if (allowUnauthenticated === false) {
+        schedulerCommand.push('--oidc-service-account-email=' + options.account);
+        schedulerCommand.push('--oidc-token-audience=' + serviceUrl);
+    }
+
+    if (options.dryrun) {
+        displayCommand('gcloud', schedulerCommand);
+    } else {
+        const createScheduler = spawn('gcloud', schedulerCommand);
+        if (options.verbose) {
+            if (createScheduler.stdout.toString('utf8') !== '') console.log(createScheduler.stdout.toString('utf8'));
+            if (createScheduler.stderr.toString('utf8') !== '') console.log(createScheduler.stderr.toString('utf8'));
+        }
+        if (createScheduler.status === 0) {
+            console.log(success('Cloud Scheduler trigger created.'));
+            await saveConfig('trigger', 'name', jobName);
+            await saveConfig('trigger', 'type', 'scheduler');
+        } else {
+            console.log(failure('Cloud Scheduler trigger failed.'));
+            process.exit(1);
+        }
+    }
+};
+
+/**
+ * Check to see if a service account already exists.
+ * @param {string} serviceAccountToCheck - Service account name.
+ * @param {boolean} verbose - Verbosity.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
+ */
+function checkServiceAccount(serviceAccountToCheck, verbose, dryrun) {
+    return new Promise(async (resolve, reject) => {
+        let command = ['iam', 'service-accounts', 'list', '--format=json'];
+
+        const getServiceAccounts = spawn('gcloud', command);
+        if (verbose) {
+            if (getServiceAccounts.stdout.toString('utf8') !== '') console.log(getServiceAccounts.stdout.toString('utf8'));
+            if (getServiceAccounts.stderr.toString('utf8') !== '') console.log(getServiceAccounts.stderr.toString('utf8'));
+        }
+        if (getServiceAccounts.status === 0) {
+            let serviceAccountList = JSON.parse(getServiceAccounts.stdout);
+            for (let account in serviceAccountList) {
+                if (serviceAccountList[account].email === serviceAccountToCheck) {
+                    console.log(success('Service account (' + varFmt(serviceAccountToCheck) + ') found.'));
+                    return resolve();
+                }
+            }
+            console.log(warn('Service account not found. Attempting to create...'));
+            await createServiceAccount(serviceAccountToCheck, verbose, dryrun);
+            return resolve();
+        } else {
+            console.log(failure('Checking if service account exists failed.'));
+            process.exit(1);
+        }
+    });
+}
+
+/**
+ * Create a service account that will be used to invoke the Cloud Run service.
+ * @param {string} serviceAccount - Service account name.
+ * @param {boolean} verbose - Verbosity.
+ * @param {boolean} dryrun - Perform the actions or simply do a dry tun test and display what would be done.
+ */
+function createServiceAccount(serviceAccount, verbose, dryrun) {
+    return new Promise(async (resolve, reject) => {
+        let serviceName = getConfig('name');
+
+        let command = ['iam', 'service-accounts', 'create', serviceName + '-invoker', '--display-name="Invoker for ' + serviceName + ' Cloud Run Service"'];
+
+        const accountCreate = spawn('gcloud', command);
+        if (verbose) {
+            if (accountCreate.stdout.toString('utf8') !== '') console.log(accountCreate.stdout.toString('utf8'));
+            if (accountCreate.stderr.toString('utf8') !== '') console.log(accountCreate.stderr.toString('utf8'));
+        }
+        if (accountCreate.status === 0) {
+            console.log(success('Service Account created: ') + varFmt(serviceAccount));
+            return resolve();
+        } else {
+            console.log(failure('Creating Service Account failed.'));
+            process.exit(1);
+        }
+    });
+}
+
+/**
+ * Ask the user for which service account for Cloud Scheduler to use to invoke the Cloud Run service. Only used if allow-unauthenticated is set to false on the Cloud Run service.
+ * @returns {string} - Name of the service account.
+ */
+function determineServiceAccount() {
+    return new Promise(async (resolve, reject) => {
+        inquirer
+            .prompt([
+                {
+                    type: 'input',
+                    name: 'serviceAccount',
+                    prefix: questionPrefix,
+                    message: 'What service account would you like to use (name only, not email)?'
+                }
+            ])
+            .then(async function(answers) {
+                // Do some very basic checking to see if it's just the name and not the full email.
+                if (answers.serviceAccount.includes('@')) {
+                    console.log(failure('Invalid service account name.'));
+                    process.exit(1);
+                }
+                return resolve(answers.serviceAccount);
+            });
+    });
+}
+
+/**
+ * Ask the user for their desired Cloud Scheduler schedule.
+ * @returns {string} - Returns a cron string.
+ */
+function determineSchedule() {
+    return new Promise(async (resolve, reject) => {
+        inquirer
+            .prompt([
+                {
+                    type: 'list',
+                    name: 'interval',
+                    prefix: questionPrefix,
+                    message: 'What schedule interval would you like to use?',
+                    choices: ['every minute', 'every 5 minutes', 'hourly', 'daily (midnight)', 'custom']
+                }
+            ])
+            .then(async function(answers) {
+                if (answers.interval === 'every minute') return resolve('*/1 * * * *');
+                else if (answers.interval === 'every 5 minutes') return resolve('*/5 * * * *');
+                else if (answers.interval === 'hourly') return resolve('0 * * * *');
+                else if (answers.interval === 'daily (midnight)') return resolve('0 0 * * *');
+                else if (answers.interval === 'custom') return resolve(await determineCustomInterval());
+            });
+    });
+}
+
+/**
+ * Ask user for their custom Cloud Scheduler interval (this is prompted if a default option is not selected.)
+ * @returns {string} - Returns a cron string.
+ */
+function determineCustomInterval() {
+    return new Promise(async (resolve, reject) => {
+        console.log();
+        console.log(warn('Custom interval must be in unix-cron format. More information:'));
+        console.log(warn('\t- Cloud Scheduler Documentation: ' + clc.blue('https://cloud.google.com/scheduler/docs/configuring/cron-job-schedules#defining_the_job_schedule')));
+        console.log(warn('\t- crontab manual page: ' + clc.blue('http://man7.org/linux/man-pages/man5/crontab.5.html\n')));
+        inquirer
+            .prompt([
+                {
+                    type: 'input',
+                    name: 'customInterval',
+                    prefix: questionPrefix,
+                    message: 'What custom interval would you like to use?'
+                }
+            ])
+            .then(async function(answers) {
+                // Do some very basic checking to see if it's in unix-cron format.
+                if (answers.customInterval.split(' ').length === 5) return resolve(answers.customInterval);
+                else {
+                    console.log(failure('Invalid cron format.'));
+                    process.exit(1);
+                }
+            });
+    });
+}
+
+/**
+ * Ask the user which HTTP method to use to invoke the Cloud Run service.
+ * @returns {string} - HTTP method type.
+ */
+function determineHttpMethod() {
+    return new Promise(async (resolve, reject) => {
+        inquirer
+            .prompt([
+                {
+                    type: 'list',
+                    name: 'method',
+                    prefix: questionPrefix,
+                    message: 'What HTTP Method would you like to use to call the Cloud Run service?',
+                    choices: ['GET', 'POST', 'PUT']
+                }
+            ])
+            .then(async function(answers) {
+                return resolve(answers.method);
+            });
+    });
+}
+
+/**
+ * Ask the user what message body to send to the Cloud Run service (if using HTTP Method of PUT or POST).
+ * @returns {string} - Message body.
+ */
+function determineMessageBody() {
+    return new Promise(async (resolve, reject) => {
+        inquirer
+            .prompt([
+                {
+                    type: 'input',
+                    name: 'messageBody',
+                    prefix: questionPrefix,
+                    message: 'What data payload do you want included as the body of the HTTP request?'
+                }
+            ])
+            .then(async function(answers) {
+                return resolve(answers.messageBody);
+            });
+    });
+}
+
+module.exports = schedulerCreate;

--- a/trigger/delete/scheduler/index.js
+++ b/trigger/delete/scheduler/index.js
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+const spawn = require('child_process').spawnSync;
+const fs = require('fs-extra');
+const inquirer = require('inquirer');
+const enableAPI = require('../../../lib/enableAPI');
+
+const displayCommand = require('../../../lib/displayCommand');
+const { success, warn, failure, header, questionPrefix, varFmt, clc } = require('../../../lib/colorScheme');
+const { saveConfig, getConfig, removeConfigSection } = require('../../../lib/parseConfig');
+
+/**
+ * Create a Cloud Scheduler trigger to call the Cloud Run service on an interval.
+ * @param {object} options - Initialized from commander.js.
+ */
+const schedulerDelete = async function(options) {
+    console.log(header('\n=== Cloud Scheduler Trigger Deletion\n'));
+
+    if (getConfig('trigger', 'type') !== 'scheduler') {
+        console.log(failure('The trigger created is not a Cloud Scheduler trigger. Exiting...'));
+        process.exit(1);
+    }
+
+    let jobName = getConfig('trigger', 'name');
+
+    let command = ['scheduler', 'jobs', 'delete', jobName, '--quiet'];
+
+    if (options.dryrun) {
+        displayCommand('gcloud', command);
+    } else {
+        const deleteScheduler = spawn('gcloud', command);
+        if (options.verbose) {
+            if (deleteScheduler.stdout.toString('utf8') !== '') console.log(deleteScheduler.stdout.toString('utf8'));
+            if (deleteScheduler.stderr.toString('utf8') !== '') console.log(deleteScheduler.stderr.toString('utf8'));
+        }
+        if (deleteScheduler.status === 0) {
+            let serviceAccount = getConfig('trigger', 'serviceAccount');
+            console.log(success('Cloud Scheduler job deleted: ' + varFmt(jobName)));
+            console.log(warn('The following service account was used: ' + varFmt(serviceAccount)));
+            console.log(warn('If the service account is no longer needed, remove it manually with: ' + clc.yellow('gcloud iam service-accounts delete ' + serviceAccount)));
+            await removeConfigSection('trigger').catch((e) => {});
+        } else {
+            console.log(failure('Cloud Scheduler job deletion failed.'));
+            process.exit(1);
+        }
+    }
+};
+
+module.exports = schedulerDelete;

--- a/trigger/delete/scheduler/index.js
+++ b/trigger/delete/scheduler/index.js
@@ -49,9 +49,11 @@ const schedulerDelete = async function(options) {
     }
     if (deleteScheduler.status === 0) {
         let serviceAccount = getConfig('trigger', 'serviceAccount');
-        console.log(success('Cloud Scheduler job deleted: ' + varFmt(jobName)));
-        console.log(warn('The following service account was used: ' + varFmt(serviceAccount)));
-        console.log(warn('If the service account is no longer needed, remove it manually with: ' + clc.yellow('gcloud iam service-accounts delete ' + serviceAccount)));
+        if (serviceAccount !== undefined) {
+            console.log(success('Cloud Scheduler job deleted: ' + varFmt(jobName)));
+            console.log(warn('The following service account was used: ' + varFmt(serviceAccount)));
+            console.log(warn('If the service account is no longer needed, remove it manually with: ' + clc.yellow('gcloud iam service-accounts delete ' + serviceAccount)));
+        }
         await removeConfigSection('trigger').catch((e) => {});
     } else {
         console.log(failure('Cloud Scheduler job deletion failed.'));


### PR DESCRIPTION
### Added

-   Added the `trigger:create:scheduler` and `trigger:delete:scheduler` commands to allow creating/deleting a Cloud Scheduler job to trigger the Cloud Run service. This supports both authenticated and unauthenticated invocations, and will create/setup service account as needed. `trigger:delete:scheduler` is invoked automatically with `crwt destroy`. This is the first of other potential trigger:[create/delete]:{method} triggers.
-   Updated the `backend-gcloud-dataflow` template's README.md to utilize `trigger:create:scheduler`.
-   Documentation and formatting fixes.
-   Re-ordered commands in help to be alphabetized in list (excluding init).
-   Built in the initial deploy call from `crbt init` to `crbt deploy` which previously required manual execution.

### Fixed

-   Resolved an issue where sufficient permissions were not granted to Cloud Build service account with GKE.
-   Changed the way the `cloudrun` section within the `.crbt` configuration file is stored. Previously used a more complex approach based on earlier prototype approaches. The `parseConfig` library and references were updated to reflect.